### PR TITLE
Update: Micropostの文字数制限

### DIFF
--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,2 +1,3 @@
 class Micropost < ApplicationRecord
+  validates :content, length: { maximum: 140 }
 end


### PR DESCRIPTION
close
https://github.com/zskteam-20200810-0947/zsksample_rails01/issues/12

## 概要

・Micropostの文字数を140文字に制限

## 修正内容の検証方法

・ローカル環境において、/microposts/newにアクセスし、140文字以上を入力

## この修正が正しい理由

・下記の画像のようなエラーが発生する。
https://i.gyazo.com/e975dbd37056711131d4fe3cfb6a3eee.png

・テストでの検証は別のissueで確認する。
